### PR TITLE
Updated distrobox build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Afterwards, follow steps 1 & 2 to build the ISO...
 
 - Create The Container :
 ```
-distrobox create -i quay.io/toolbx-images/archlinux-toolbox -n "xerobuilder"
+distrobox create -i quay.io/toolbx-images/archlinux-toolbox -n "xerobuilder" --root  
 ```
 
 - Enter the Container :


### PR DESCRIPTION
Hello, I have updated the distrobox setup instructions to include --root when creating the container, because otherwise the build will fail, giving permission denied errors. See https://github.com/89luca89/distrobox/blob/main/docs/useful_tips.md#run-the-container-with-real-root